### PR TITLE
Cross reference and sequence name route

### DIFF
--- a/flaskr/nscope/views.py
+++ b/flaskr/nscope/views.py
@@ -122,3 +122,4 @@ def get_metadata(oeis_id):
     seq_file = open(meta_filename)
     seq_dict = json.load(seq_file)
     return (jsonify(seq_dict))
+    

--- a/flaskr/nscope/views.py
+++ b/flaskr/nscope/views.py
@@ -122,4 +122,3 @@ def get_metadata(oeis_id):
     seq_file = open(meta_filename)
     seq_dict = json.load(seq_file)
     return (jsonify(seq_dict))
-    

--- a/flaskr/nscope/views.py
+++ b/flaskr/nscope/views.py
@@ -102,14 +102,13 @@ def get_metadata(oeis_id):
             #Checking for valid OEIS ID
             if req['results'] != None: #Checking for valid OEIS ID
                 results = req['results'][0]
+                seq_data = {}
                 if 'name' in results.keys():
-                    seq_name = results['name']
-                    seq_data = {'name':seq_name}
+                    seq_data['name'] = results['name']
                 else:
-                    seq_data = {'name':f' Sequence A{oeis_id[1:]} has no name.'}
+                    seq_data['name'] = f' Sequence A{oeis_id[1:]} has no name.'
                 if 'xref' in results.keys():
-                    seq_xref = results['xref']
-                    seq_data['xref'] = seq_xref
+                    seq_data['xref'] = results['xref']
                 else: 
                     seq_data['xref'] = f' Sequence A{oeis_id[1:]} has no xref data.'
                 json_dump = json.dumps(seq_data)


### PR DESCRIPTION
Resolves #17 
New `bp.route` called `/api/get_metadata` that gets the OEIS sequence name and its cross reference data if it exists.
uses the JSON format OEIS URL and stores data as JSON with `'name'` and `'xref'` as keys.