### PR TITLE
feat: Add endpoints for sequence metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,9 @@ This should print a series of messages starting with
 "Serving Flask app 'flaskr'" and ending with debugger information. One of these
 messages should be the URL the server is running on, typically
 `http://127.0.0.1:5000/`. To test that the server is working correctly,
-try visiting "<URL>/api/get_oeis_values/A000045/50" (substitute in the server
-URL for "<URL>" -- this should display the first 50 terms of the sum recurrence.
+try visiting "<URL>/api/get_oeis_values/A000030/50" (substitute in the server
+URL for "<URL>" -- this should display the first digits of the numbers from
+0 through 49.
 
 ## Resetting the database
 
@@ -150,7 +151,7 @@ All of them return JSON data with the specified keys and values. Also, every
 endpoint includes the key 'id' with value the OEIS id for the sake of verifying
 that it is the data as requested. In case of an OEIS_ID that does not match
 anything in the OEIS, an error string is returned. Note that the angle brackets
-<> in the URLS indicate where subsitutions are made, they should not be present
+<> in the URLS indicate where subsitutions are made; they should not be present
 in the URLs actually used.
 
 Also note that if any of the requests are made for a given sequence, then the
@@ -161,7 +162,10 @@ going back to the OEIS.
 ### URL: api/get_oeis_values/<OEIS_ID>/<COUNT>
 
 This is the most rapid endpoint, it makes at most one request to the OEIS server
-(and only if the OEIS_ID has not previously been requested).
+(and only if the OEIS_ID has not previously been requested). If you are running
+the server to test it on your local host, a full URL would be
+`http://127.0.0.1:5000/api/get_oeis_values/A000030/50` which will return the
+first digits of the numbers 0 through 49.
 
 #### Key: name
 
@@ -178,7 +182,10 @@ datatype.
 ### URL: api/get_oeis_name_and_values/<OEIS_ID>
 
 Potentially a bit slower than the above URL, it may make an extra request to
-ensure that the name is correct.
+ensure that the name is correct. If you are running the server on your local
+host, a full URL would be `http://127.0.0.1:5000/api/get_oeis_values/A003173`
+which will return the nine Heegner numbers and their full name as an OEIS
+sequence (basically, the name describes what a Heegner number is).
 
 #### Key: name
 
@@ -193,7 +200,11 @@ OEIS_ID known to the OEIS.
 
 A potentially very slow endpoint (if the sequence is unknown to the backscope);
 may make hundreds of requests to the OEIS to generate all of the back
-references to the sequence.
+references to the sequence. If you are running the server on your local
+machine, a full URL would be
+`http://127.0.0.1:5000/api/get_oeis_metadata/A028444` which will show the full
+name of the Busy Beaver sequence, the one text line of sequences it
+references, and the IDs of the ten sequences that refer to it.
 
 #### Key: name
 

--- a/README.md
+++ b/README.md
@@ -157,9 +157,11 @@ in the URLs actually used.
 Also note that if any of the requests are made for a given sequence, then the
 back end will in the background obtain all of the data necessary to respond
 to all of the endpoints for future requests concerning that sequence without
-going back to the OEIS.
+going back to the OEIS. Note that this background work may take an appreciable
+amount of time, especially if the sequence has lots of references within the
+OEIS.
 
-### URL: api/get_oeis_values/<OEIS_ID>/<COUNT>
+### URL: `api/get_oeis_values/<OEIS_ID>/<COUNT>`
 
 This is the most rapid endpoint, it makes at most one request to the OEIS server
 (and only if the OEIS_ID has not previously been requested). If you are running
@@ -179,24 +181,25 @@ with id OEIS_ID. Since some sequence values correspond to extremely large
 numbers, strings are used to avoid the limitations of any particular numeric
 datatype.
 
-### URL: api/get_oeis_name_and_values/<OEIS_ID>
+### URL: `api/get_oeis_name_and_values/<OEIS_ID>`
 
-Potentially a bit slower than the above URL, it may make an extra request to
-ensure that the name is correct. If you are running the server on your local
-host, a full URL would be `http://127.0.0.1:5000/api/get_oeis_values/A003173`
-which will return the nine Heegner numbers and their full name as an OEIS
+This one is potentially a bit slower than the above URL, as it may make
+an extra request to ensure that the name is correct. If you are running
+the server on your local host, a full URL would be
+`http://127.0.0.1:5000/api/get_oeis_name_and_values/A003173`, which will
+return the nine Heegner numbers and their full name as an OEIS
 sequence (basically, the name describes what a Heegner number is).
 
 #### Key: name
 
-A string giving the official name of the OEIS sequence with id OEIS_ID
+A string giving the official name of the OEIS sequence with id OEIS_ID.
 
 #### Key: values
 
 An array of strings (of digits) giving all values of the sequence with id
 OEIS_ID known to the OEIS.
 
-### URL: api/get_oeis_metadata/<OEIS_ID>
+### URL: `api/get_oeis_metadata/<OEIS_ID>`
 
 A potentially very slow endpoint (if the sequence is unknown to the backscope);
 may make hundreds of requests to the OEIS to generate all of the back
@@ -208,7 +211,7 @@ references, and the IDs of the ten sequences that refer to it.
 
 #### Key: name
 
-A string giving the official name of the OEIS sequence with id OEIS_ID
+A string giving the official name of the OEIS sequence with id OEIS_ID.
 
 #### Key: xrefs
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,71 @@ $ python3 manage.py db upgrade
 
 Now you should again be ready to run the backscope server.
 
+## Endpoints
+
+This section documents all of the endpoints provided by the backscope server.
+All of them return JSON data with the specified keys and values. Also, every
+endpoint includes the key 'id' with value the OEIS id for the sake of verifying
+that it is the data as requested. In case of an OEIS_ID that does not match
+anything in the OEIS, an error string is returned. Note that the angle brackets
+<> in the URLS indicate where subsitutions are made, they should not be present
+in the URLs actually used.
+
+Also note that if any of the requests are made for a given sequence, then the
+back end will in the background obtain all of the data necessary to respond
+to all of the endpoints for future requests concerning that sequence without
+going back to the OEIS.
+
+### URL: api/get_oeis_values/<OEIS_ID>/<COUNT>
+
+This is the most rapid endpoint, it makes at most one request to the OEIS server
+(and only if the OEIS_ID has not previously been requested).
+
+#### Key: name
+
+A string giving the official name of the OEIS sequence with id OEIS_ID,
+if already known to backscope, or a temporary name if not.
+
+#### Key: values
+
+An array of _strings_ (of digits) giving the first COUNT values of the sequence
+with id OEIS_ID. Since some sequence values correspond to extremely large
+numbers, strings are used to avoid the limitations of any particular numeric
+datatype.
+
+### URL: api/get_oeis_name_and_values/<OEIS_ID>
+
+Potentially a bit slower than the above URL, it may make an extra request to
+ensure that the name is correct.
+
+#### Key: name
+
+A string giving the official name of the OEIS sequence with id OEIS_ID
+
+#### Key: values
+
+An array of strings (of digits) giving all values of the sequence with id
+OEIS_ID known to the OEIS.
+
+### URL: api/get_oeis_metadata/<OEIS_ID>
+
+A potentially very slow endpoint (if the sequence is unknown to the backscope);
+may make hundreds of requests to the OEIS to generate all of the back
+references to the sequence.
+
+#### Key: name
+
+A string giving the official name of the OEIS sequence with id OEIS_ID
+
+#### Key: xrefs
+
+A string which is the concatenation (separated by newlines) of all of the
+OEIS text "xref" records for the sequence with id OEIS_ID.
+
+#### Key: backrefs
+
+An array of strings giving all OEIS ids that mention the given OEIS_ID.
+
 ## Other information about the backscope project
 
 ### Description of Directories:

--- a/TODO.md
+++ b/TODO.md
@@ -1,1 +1,0 @@
-- [ ] have a way to handle offset sequences that start at a non-zero index

--- a/flaskr/nscope/models.py
+++ b/flaskr/nscope/models.py
@@ -38,6 +38,7 @@ class Sequence(db.Model):
     shift = db.Column(db.Integer, unique=False, nullable=False, default=0)
     values = db.Column(db.ARRAY(db.String), unique=False, nullable=False)
     raw_refs = db.Column(db.String, unique=False, nullable=True)
+    backrefs = db.Column(db.ARRAY(db.String), unique=False, nullable=True)
 
     @classmethod
     def get_seq_by_id(self, id):

--- a/flaskr/nscope/views.py
+++ b/flaskr/nscope/views.py
@@ -35,7 +35,13 @@ def index():
 def save_oeis_sequence(seq):
     # When we arrive here, we have a Sequence object seq which has had its
     # values filled in. We grab its metadata and incorporate that, and then
-    # add it to the database, and return the fleshed-out sequence
+    # add it to the database, and return the fleshed-out sequence.
+    # NOTE however that nothing currently prevents two requests
+    # for the same newly-encountered sequence ending up both getting to this
+    # code at roughly the same time (if the second comes in before the first
+    # has had a chance to fill in the database). In that case, all of the
+    # lookup work will be duplicated, although Postgres should ensure that when
+    # all is said and done, the database is left in an OK state.
     match_url = f"https://oeis.org/search?q={seq.id}&fmt=json"
     r = requests.get(match_url).json()
     if r['results'] != None: # Found some metadata

--- a/flaskr/nscope/views.py
+++ b/flaskr/nscope/views.py
@@ -33,19 +33,48 @@ def index():
     return render_template("index.html")
 
 def save_oeis_sequence(seq):
+    # When we arrive here, we have a Sequence object seq which has had its
+    # values filled in. We grab its metadata and incorporate that, and then
+    # add it to the database, and return the fleshed-out sequence
+    match_url = f"https://oeis.org/search?q={seq.id}&fmt=json"
+    r = requests.get(match_url).json()
+    if r['results'] != None: # Found some metadata
+        backrefs = []
+        target_number = int(seq.id[1:])
+        matches = r['count']
+        saw = 0
+        while (saw < matches):
+            for result in r['results']:
+                if result['number'] == target_number:
+                    seq.name = result['name']
+                    seq.raw_refs = "\n".join(result['xref'])
+                else:
+                    backrefs.append('A' + str(result['number']).zfill(6))
+                saw += 1
+            if saw < matches:
+                r = requests.get(match_url + f"&start={saw}").json()
+                if r['results'] == None:
+                    break
+        seq.backrefs = backrefs
     db.session.add(seq)
     db.session.commit()
+    return seq
 
-def find_oeis_sequence(oeis_id):
+def find_oeis_sequence(oeis_id, detail = ''):
     """ Returns either a Sequence object, or an Error object if ID invalid, etc.
         Note it _returns_ the Error object, rather than throwing it.
+        If the optional second argument is a string with special values:
+        'name' means to make an extra request to get the official name, and
+        'full' means to wait to get all of the sequence data from the OEIS
+        server; otherwise it only retrieves the values and leaves extraction
+        of other information to a background task.
     """
     # First check if it is in the database
     seq = Sequence.get_seq_by_id(oeis_id)
     if seq: return seq
     # Try to get it from the OEIS:
-    seq_addr = "https://oeis.org/{}/b{}.txt".format(oeis_id, oeis_id[1:])
-    r = requests.get(seq_addr)
+    domain = 'https://oeis.org/'
+    r = requests.get(f"{domain}{oeis_id}/b{oeis_id[1:]}.txt")
     if r.status_code == 404:
         return LookupError(f"B-file for ID '{oeis_id}' not found in OEIS.")
     # Parse the b-file:
@@ -69,11 +98,21 @@ def find_oeis_sequence(oeis_id):
     if last < first:
         return IndexError(f"No terms found for ID '{oeis_id}'.")
     vals = [seq_vals[i] for i in range(first,last+1)]
-    # Fill in some placeholder until we look up the real name.
-    # Should we flag this in some way so it can be filtered from display?
+
+    if detail == 'name':
+        r = requests.get(f"{domain}search?q=id:{oeis_id}&fmt=json").json()
+        if r['results'] != None:
+            name = r['results'][0]['name']
+
+    # If need be, fill in a placeholder until we look up the real name.
     if not name: name = f"{oeis_id} [name not yet loaded]"
+
     seq = Sequence(id=oeis_id, name=name, shift=first, values=vals)
-    # Schedule the database interaction so we can respond to the
+    if detail == 'full':
+        # Get all of the data and make sure it's in the database synchronously
+        # as requested
+        return save_oeis_sequence(seq)
+    # Otherwise, schedule the database interaction so we can respond to the
     # request immediately:
     executor.submit(save_oeis_sequence, seq)
     return seq
@@ -90,3 +129,23 @@ def get_oeis_values(oeis_id, num_elements):
     vals = {(i+seq.shift):raw_vals[i] for i in range(len(raw_vals))}
 
     return jsonify({'id': seq.id, 'name': seq.name, 'values': vals})
+
+@bp.route("/api/get_oeis_name_and_values/<oeis_id>", methods=["GET"])
+def get_oeis_name_and_values(oeis_id):
+    seq = find_oeis_sequence(oeis_id, 'name')
+    if isinstance(seq, Exception):
+        return f"Error: {seq}"
+    vals = {(i + seq.shift): seq.values[i] for i in range(len(seq.values))}
+    return jsonify({'id': seq.id, 'name': seq.name, 'values': vals})
+
+@bp.route("/api/get_oeis_metadata/<oeis_id>", methods=["GET"])
+def get_oeis_metadata(oeis_id):
+    seq = find_oeis_sequence(oeis_id, 'full')
+    if isinstance(seq, Exception):
+        return f"Error: {seq}"
+    return jsonify({
+        'id': seq.id,
+        'name': seq.name,
+        'xrefs': seq.raw_refs,
+        'backrefs': seq.backrefs
+    })

--- a/flaskr/nscope/views.py
+++ b/flaskr/nscope/views.py
@@ -91,6 +91,9 @@ def find_oeis_sequence(oeis_id, detail = ''):
             continue
         column = line.split()
         if len(column) < 2: continue
+        if not column[0][0].isdigit():
+            return LookupError(
+                f"Unparseable b-file line for ID '{oeis_id}': {line}")
         index = int(column[0])
         if index < first: first = index
         if index > last:  last  = index


### PR DESCRIPTION
  Specifically, api/get_oeis_name_and_values/<OEIS_ID> is guaranteed
  to give the correct official OEIS name of the sequence, and
  api/get_oeis_metadata/<OEIS_ID> which returns the official name,
  cross references, and beack references to the sequence.

  Documents these in the README (as there isn't really any other documentation
  place at the moment).

  Also removes the obsolete TODO.md (it only had one item, which is done, and
  we mostly rely on GitHub issues for todos now anyway).

  Resolves #17.

Basically, this is just a version of #26 compatible with the new resolve to only store data in the database, and that PR should be closed once this is merged.