### PR TITLE
add factoring endpoint to backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,40 @@ OEIS text "xref" records for the sequence with id OEIS_ID.
 
 An array of strings giving all OEIS ids that mention the given OEIS_ID.
 
+### URL: `api/get_oeis_factors/<OEIS_ID>/<COUNT>`
+
+This could take a long time.  It does everything that the endpoint
+`get_oeis_metadata` does, and then once the result is stored in the database
+it will then proceed to factor the first `<COUNT>` terms, or all the terms,
+whichever is less.  If you are running the server to test it on your local 
+host, a full URL would be
+`http://127.0.0.1:5000/api/get_oeis_factors/A006862/50` which will return the
+factorizations of 1 + the product of the first n primes, for n < 50.  The 
+first 42 terms will be factored and larger terms will return `None` (since 
+they are deemed too large to factor in a reasonable time).
+
+The factorization is performed by pari:
+`https://pari.math.u-bordeaux.fr/`
+Previous factorization requests are cached in the database for efficiency.
+
+#### Key: name
+
+A string giving the official name of the OEIS sequence with id OEIS_ID,
+if already known to backscope, or a temporary name if not.
+
+#### Key: factors
+
+An array whose indices match the indices of the values of the sequence.
+The format of each entry is a string of the form `[ [p,e], [q,f], ... ]` 
+where each entry `[p,e]` represents a factor of the prime p to the power e.  
+If an integer is negative, `[-1,1]` is included.  If the integer is 1, the 
+factorization is `[]` (empty).  If the integer is 0, the factorization 
+is `[[0,1]]`.  Any successful factorization has the property that if you 
+multiply 1 times the product of `p^e` for all `[p,e]` in the array, you 
+obtain the original value. This format is essentially that supported by pari.
+If the integer exceeds 2^200, the factorization is not attempted and 
+the factorization is stored as `None`.  
+
 ## Other information about the backscope project
 
 ### Description of Directories:

--- a/README.md
+++ b/README.md
@@ -224,19 +224,19 @@ An array of strings giving all OEIS ids that mention the given OEIS_ID.
 
 ### URL: `api/get_oeis_factors/<OEIS_ID>/<COUNT>`
 
-This could take a long time.  It does everything that the endpoint
+This could take a long time.  It internally does everything that the endpoint
 `get_oeis_metadata` does, and then once the result is stored in the database
-it will then proceed to factor the first `<COUNT>` terms, or all the terms,
-whichever is less.  If you are running the server to test it on your local 
-host, a full URL would be
+it proceeds to factor the first `<COUNT>` terms of the sequence (or all of them
+if there are not that many). If you are running the server to test it on your
+local host, a full URL would be
 `http://127.0.0.1:5000/api/get_oeis_factors/A006862/50` which will return the
-factorizations of 1 + the product of the first n primes, for n < 50.  The 
-first 42 terms will be factored and larger terms will return `None` (since 
+factorizations of 1 + the product of the first n primes, for n < 50.  The
+first 42 terms will be factored and larger terms will return `no_fac` (since
 they are deemed too large to factor in a reasonable time).
 
-The factorization is performed by pari:
-`https://pari.math.u-bordeaux.fr/`
+The factorization is performed by pari: `https://pari.math.u-bordeaux.fr/`.
 Previous factorization requests are cached in the database for efficiency.
+Returns the following data:
 
 #### Key: name
 
@@ -245,18 +245,18 @@ A string giving the official name of the OEIS sequence with id OEIS_ID.
 #### Key: factors
 
 An array whose indices match the indices of the values of the sequence.
-The format of each entry is a string of the form 
+The format of each entry is a string of the form
 
-`[[p,e],[q,f],...]` 
+`[[p,e],[q,f],...]`
 
 where each entry `[p,e]` represents a factor of the prime p to the power e.  If
-an integer is negative, `[-1,1]` is included.  If the integer is 1, the 
-factorization is `[]` (empty).  If the integer is 0, the factorization 
-is `[[0,1]]`.  Any successful factorization has the property that if you 
-multiply 1 times the product of `p^e` for all `[p,e]` in the array, you 
+an integer is negative, `[-1,1]` is included.  If the integer is 1, the
+factorization is `[]` (empty).  If the integer is 0, the factorization
+is `[[0,1]]`.  Any successful factorization has the property that if you
+multiply 1 times the product of `p^e` for all `[p,e]` in the array, you
 obtain the original value. This format is essentially that supported by pari.
-If the integer exceeds 2^200, the factorization is not attempted and 
-the factorization is stored as `None`.  
+If the integer exceeds 2^200, the factorization is not attempted and
+the factorization is stored as `no_fac`.
 
 ## Other information about the backscope project
 

--- a/README.md
+++ b/README.md
@@ -246,9 +246,12 @@ if already known to backscope, or a temporary name if not.
 #### Key: factors
 
 An array whose indices match the indices of the values of the sequence.
-The format of each entry is a string of the form `[ [p,e], [q,f], ... ]` 
-where each entry `[p,e]` represents a factor of the prime p to the power e.  
-If an integer is negative, `[-1,1]` is included.  If the integer is 1, the 
+The format of each entry is a string of the form 
+
+`[ [p,e], [q,f], ... ]` 
+
+where each entry `[p,e]` represents a factor of the prime p to the power e.  If
+an integer is negative, `[-1,1]` is included.  If the integer is 1, the 
 factorization is `[]` (empty).  If the integer is 0, the factorization 
 is `[[0,1]]`.  Any successful factorization has the property that if you 
 multiply 1 times the product of `p^e` for all `[p,e]` in the array, you 

--- a/README.md
+++ b/README.md
@@ -240,15 +240,14 @@ Previous factorization requests are cached in the database for efficiency.
 
 #### Key: name
 
-A string giving the official name of the OEIS sequence with id OEIS_ID,
-if already known to backscope, or a temporary name if not.
+A string giving the official name of the OEIS sequence with id OEIS_ID.
 
 #### Key: factors
 
 An array whose indices match the indices of the values of the sequence.
 The format of each entry is a string of the form 
 
-`[ [p,e], [q,f], ... ]` 
+`[[p,e],[q,f],...]` 
 
 where each entry `[p,e]` represents a factor of the prime p to the power e.  If
 an integer is negative, `[-1,1]` is included.  If the integer is 1, the 

--- a/flaskr/nscope/models.py
+++ b/flaskr/nscope/models.py
@@ -39,6 +39,9 @@ class Sequence(db.Model):
     values = db.Column(db.ARRAY(db.String), unique=False, nullable=False)
     raw_refs = db.Column(db.String, unique=False, nullable=True)
     backrefs = db.Column(db.ARRAY(db.String), unique=False, nullable=True)
+    # Sadly, multidimensional arrays can't vary in dimension
+    # so we store factorization arrays as strings
+    factors = db.Column(db.ARRAY(db.String), unique=False, nullable=True)
 
     @classmethod
     def get_seq_by_id(self, id):

--- a/flaskr/nscope/views.py
+++ b/flaskr/nscope/views.py
@@ -151,14 +151,13 @@ def factor_oeis_sequence(seq, num_elements):
         stored as a string (since flask doesn't allow multidimensional
         arrays with varying sizes).
     """
-    # The hardcoded integer size limit below can be pushed 
-    # further once we are doing factoring tasks on a 
-    # background queue.
+    # The hardcoded integer size limit below can be pushed
+    # further once we are doing factoring tasks on a background queue.
 
     # It appears that we are obliged to re-fetch the sequence from the database
     # for the updates to occur through Flask magic:
     seq = Sequence.get_seq_by_id(seq.id)
-    if len(seq.values) < num_elements: 
+    if len(seq.values) < num_elements:
         num_elements = len(seq.values)
     # Load from database how much has been factored already
     if not seq.factors:
@@ -186,7 +185,9 @@ def factor_oeis_sequence(seq, num_elements):
             fac = 'no_fac'
         factors.append(str(fac).replace(" ",""));
     # And further it seems that we are obliged to actually modify the identity
-    # of seq.factors in order for the database to update:
+    # of seq.factors in order for the database to update. It is hard to believe
+    # that both the .copy() above and this copy() are required, yet testing
+    # appeared to confirm that.
     seq.factors = factors.copy()
     db.session.commit()
     return seq

--- a/flaskr/nscope/views.py
+++ b/flaskr/nscope/views.py
@@ -164,7 +164,8 @@ def factor_oeis_sequence(seq, num_elements):
     if not seq.factors:
         factors = []
     else:
-        factors = seq.factors
+        # this copy appears to be required for the sequence update to work
+        factors = seq.factors.copy()
     len_factors = len(factors)
     if len_factors >= num_elements:
         return seq

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 alembic==1.4.2
 click==7.1.1
+cysignals==1.11.2
+cypari2==2.1.2
 Flask==1.1.1
 Flask-Cors==3.0.8
 Flask-Executor==0.10.0
@@ -14,7 +16,7 @@ jsonify==0.5
 Mako==1.1.2
 MarkupSafe==1.1.1
 numpy==1.20.0
-psycopg2==2.9.1
+psycopg2-binary==2.9.1
 python-dateutil==2.8.1
 python-dotenv==0.12.0
 python-editor==1.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 alembic==1.4.2
 click==7.1.1
+# it appears cysignals must be installed before cypari2 install is attempted
 cysignals==1.11.2
 cypari2==2.1.2
 Flask==1.1.1
@@ -16,6 +17,7 @@ jsonify==0.5
 Mako==1.1.2
 MarkupSafe==1.1.1
 numpy==1.20.0
+# replaced psycopg2 with psycopg2-binary to avoid compile errors
 psycopg2-binary==2.9.1
 python-dateutil==2.8.1
 python-dotenv==0.12.0


### PR DESCRIPTION
This implements factoring on the backend using pari via cypari2.  Adds an endpoint that returns the requested number of factorizations.  The browser has to wait, and there's a limit on the size of integers it will be willing to factor (returning "None" as the factorization of terms which are too big).

This PR adds a column to the table ```sequences``` called ```factors```.  It contains an array the same size/indices as the array of values.  The entries are strings representing arrays, which are in the same format that pari creates when factoring.  This was chosen because mathematicians familiar with pari will be used to this and pari put some effort into the design.  For example, you can recreate the term by easily looping through the factors and multiplying, even with 1 and 0.  

Also, I replaced psycopg with psycopg-binary since I was already modifying requirements.txt.  If you want this taken out, to keep different PRs separate, just say the word. (See #23)

Things left for the future:  handle how long it may take in a more nuanced way.  Right now the browser waits until the full metadata is stored in the database and then waits until the factorizations are performed.  However, once it is all cached once, this will return quickly.  I hope this is ok as 'step 1' (so visualizers can use the functionality) and then optimization can be left for later as another issue.

Resolves #35.  Resolves #12.  Resolves #23.