### PR TITLE
fix/docs: fix `get_valid_oeis_id`, fix shell script, add shell script, add some docs

### DIFF
--- a/flaskr/nscope/views.py
+++ b/flaskr/nscope/views.py
@@ -201,12 +201,17 @@ def get_valid_oeis_id(oeis_id):
         else:
             first_character = oeis_id[0]
             if first_character.islower():
-                # TODO: This should be logged. See
-                # https://github.com/numberscope/backscope/issues/57.
-                print('info: first character in oeis_id is lowercase')
-                print('info: making first character in oeis_id uppercase')
-                valid_id = first_character.upper()
-                valid_id += oeis_id.partition(first_character)[2]
+                """
+                If we can configure logging levels, e.g. info, warn,
+                error, debug, verbose, etc., then the following print
+                statements should be (verbose?) logs.
+                
+                TODO:
+                https://github.com/numberscope/backscope/issues/57
+                """
+                print('verbose: first character in oeis_id is lowercase')
+                print('verbose: making first character in oeis_id uppercase')
+                valid_id = first_character.upper() + valid_id[1:]
     else:
         raise TypeError('oeis_id not a string')
     return valid_id

--- a/flaskr/nscope/views.py
+++ b/flaskr/nscope/views.py
@@ -205,7 +205,8 @@ def get_valid_oeis_id(oeis_id):
                 # https://github.com/numberscope/backscope/issues/57.
                 print('info: first character in oeis_id is lowercase')
                 print('info: making first character in oeis_id uppercase')
-                valid_id[0] = first_character.upper()
+                valid_id = first_character.upper()
+                valid_id += oeis_id.partition(first_character)[2]
     else:
         raise TypeError('oeis_id not a string')
     return valid_id

--- a/server/README.md
+++ b/server/README.md
@@ -8,4 +8,5 @@ Numberscope's server.
 * `numberscope.service` symlinked to `/etc/systemd/system`
 * `production.sh` run by `numberscope.service`
 
-See `create-symlinks.sh` for the actual symlink commands.
+See `create-symlinks.sh` for the actual symlink commands. To add the
+`numberscope` systemd service, run `add-numberscope-servicee.sh`.

--- a/server/add-numberscope-service.sh
+++ b/server/add-numberscope-service.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# This script should be run with sudo.
+
+systemctl daemon-reload
+systemctl enable numberscope.service

--- a/server/create-symlinks.sh
+++ b/server/create-symlinks.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 ln -s /home/scope/repos/backscope/server/numberscope.conf /etc/nginx/sites-available/numberscope.conf
 ln -s /etc/nginx/sites-available/numberscope.conf /etc/nginx/sites-enabled/numberscope.conf
-ln -s /home/scope/repos/backscope/server/numberscope.sercice /etc/systemd/system/numberscope.service
+ln -s /home/scope/repos/backscope/server/numberscope.service /etc/systemd/system/numberscope.service

--- a/server/create-symlinks.sh
+++ b/server/create-symlinks.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+# This script should be run with sudo.
+
 ln -s /home/scope/repos/backscope/server/numberscope.conf /etc/nginx/sites-available/numberscope.conf
 ln -s /etc/nginx/sites-available/numberscope.conf /etc/nginx/sites-enabled/numberscope.conf
 ln -s /home/scope/repos/backscope/server/numberscope.service /etc/systemd/system/numberscope.service


### PR DESCRIPTION
This PR:

- Fixes the `get_valid_oeis_id` function. When you tried to set `valid_id[0] = first_character.upper()`, you'd get `TypeError: 'str' object does not support item assignment`.
- Fixes a typo in a shell script.
- Adds a shell script that you can run to add the `numberscope` systemd service.
- Adds some comments, and a note to the `server/README.md` file.