### PR TITLE
docs: update README, move some docs to doc dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ You should see help for the `venv` module.
    This project uses python-dotenv. In order to detect your database
    username / password, you must create a file called `.env` in the root
    of your directory containing:
-
    ```
    export APP_SETTINGS="config.DevelopmentConfig"
    export DATABASE_URI="postgresql://localhost/<database name>"
@@ -100,7 +99,6 @@ You should see help for the `venv` module.
    export POSTGRES_DB="<database name>"
    export POSTGRES_PASSWORD="<password for psql>"
    ```
-
    You can see other configuration options inside
    [the config file](./flaskr/config.py).
 
@@ -109,10 +107,10 @@ You should see help for the `venv` module.
    ```bash
    python manage.py db init # initializes tables inside database
    ```
-
-  The previous command will issue a message about editing
-  `alembic.ini`, which is safe to ignore. The default works fine.
    
+   The previous command will issue a message about editing
+   `alembic.ini`, which is safe to ignore. The default works fine.
+
    ```bash
    python manage.py db migrate # migrate data models
    python manage.py db upgrade # upgrade changes to database

--- a/README.md
+++ b/README.md
@@ -68,10 +68,11 @@ You should see help for the `venv` module.
 
    Specifically, once you are set up, it should be possible to use the command
    `psql` to connect to a Postgres shell where you can create a database for
-   backscope.
+   backscope. You should be able to use the `-U` flag to specify a user who
+   has the correct permissions to access the Postgres shell and create a database.
 
    ```bash
-   psql
+   psql -U <username for psql>
    <username>=# CREATE DATABASE <database name>;
    CREATE DATABASE
    <username>=# \q
@@ -108,10 +109,10 @@ You should see help for the `venv` module.
    psql -d <database name>
    db=# \d
     Schema |      Name       |   Type   | Owner
-   --------+-----------------+----------+-------
-    public | alembic_version | table    | <username>
-    public | user            | table    | <username>
-    public | user_id_seq     | sequence | <username>
+   --------+-----------------+----------+--------------------
+    public | alembic_version | table    | <username for psql>
+    public | user            | table    | <username for psql>
+    public | user_id_seq     | sequence | <username for psql>
    db=# \q
    ```
 

--- a/README.md
+++ b/README.md
@@ -135,3 +135,19 @@ messages should be the URL the server is running on, typically
 try visiting `<URL>/api/get_oeis_values/A000030/50` (substitute in the server
 URL for `<URL>`). This should display the first digits of the numbers from
 0 through 49.
+
+## More information
+
+### General
+
+- [API Endpoints](./doc/api_endpoints.md)
+- [Directory Descriptions](./doc/directory_descriptions.md)
+- [Resetting the Database](./doc/resetting-the-database.md)
+
+### Administering the production backscope instance
+
+- [Update Backscope](./doc/update-backscope.md)
+- [Server Administration](./doc/server-administration.md)
+- [Database Administration](./doc/database-administration.md)
+- [server Directory README](./server/README.md)
+

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
-# backscope
+# Numberscope - backscope
 
 Copyright 2020-2022 Regents of the University of Colorado.
 
 This project is licensed under the
 [MIT License](https://opensource.org/licenses/MIT). See the text of the MIT
 License in LICENSE.md.
+
+## What is backscope?
+
+backscope is [Numberscope's](https://numberscope.colorado.edu) back end. It is
+responsible for getting sequences and other data from the [On-Line Encyclopedia
+of Integer Sequences](https://oeis.org).
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NumberscopeFlask
+# backscope
 
 Copyright 2020-2022 Regents of the University of Colorado.
 

--- a/README.md
+++ b/README.md
@@ -141,5 +141,5 @@ This should print a series of messages. One of these
 messages should be the URL the server is running on, typically
 `http://127.0.0.1:5000/`. To test that the server is working correctly,
 try visiting `<URL>/api/get_oeis_values/A000030/50` (substitute in the server
-URL for `<URL>`. This should display the first digits of the numbers from
+URL for `<URL>`). This should display the first digits of the numbers from
 0 through 49.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You should see help for the `venv` module.
 1. Create your virtual environment:
 
    ```bash
-   python -m venv .venv # Create a new virtual env called .venv
+   python -m venv .venv # create a new virtual env called .venv
    source .venv/bin/activate
    pip install -r requirements.txt
    pip install --force cypari2
@@ -81,7 +81,7 @@ You should see help for the `venv` module.
 
    ```bash
    psql
-   <username>=# CREATE DATABASE <database_name>;
+   <username>=# CREATE DATABASE <database name>;
    CREATE DATABASE
    <username>=# \q
    ```
@@ -94,11 +94,11 @@ You should see help for the `venv` module.
 
    ```
    export APP_SETTINGS="config.DevelopmentConfig"
-   export DATABASE_URI="postgresql://localhost/<database_name>"
+   export DATABASE_URI="postgresql://localhost/<database name>"
    export SECRET_KEY="Uneccessary for development"
-   export POSTGRES_USER="<user name for psql>"
-   export POSTGRES_DB="<database_name>"
-   export POSTGRES_PASSWORD="<user password for psql>"
+   export POSTGRES_USER="<username for psql>"
+   export POSTGRES_DB="<database name>"
+   export POSTGRES_PASSWORD="<password for psql>"
    ```
 
    You can see other configuration options inside
@@ -116,7 +116,7 @@ You should see help for the `venv` module.
    ```bash
    python manage.py db migrate # migrate data models
    python manage.py db upgrade # upgrade changes to database
-   psql -d <database_name>
+   psql -d <database name>
    db=# \d
     Schema |      Name       |   Type   | Owner
    --------+-----------------+----------+-------
@@ -142,6 +142,6 @@ flask run
 This should print a series of messages. One of these
 messages should be the URL the server is running on, typically
 `http://127.0.0.1:5000/`. To test that the server is working correctly,
-try visiting "<URL>/api/get_oeis_values/A000030/50" (substitute in the server
-URL for "<URL>" -- this should display the first digits of the numbers from
+try visiting `<URL>/api/get_oeis_values/A000030/50` (substitute in the server
+URL for `<URL>`. This should display the first digits of the numbers from
 0 through 49.

--- a/README.md
+++ b/README.md
@@ -57,60 +57,42 @@ python -m venv -h
 
 You should see help for the `venv` module.
 
-Set up initial dependencies:
+### Create a virtual environment and install dependencies
 
-1. Source / create your python environment:
+1. Create your virtual environment:
 
    ```bash
-   $ virtualenv -p python3 .venv # Create a new virtual env called .venv
-   $ source .venv/bin/activate
-   $ pip install -r requirements.txt
-   $ pip install --force cypari2
+   python -m venv .venv # Create a new virtual env called .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   pip install --force cypari2
    ```
 
-   If you use a different python package manager, install requirements through this instead
-
-2. Install and configure postgresql and create an empty database
+2. Install and configure PostgreSQL and create an empty database:
 
    Specific instructions for PostgreSQL installation are unfortunately beyond
    the current scope of this README, as they depend greatly on the particulars
-   of the operating system you are using. You need to end up with a running
-   postgresql server on your machine that will accept localhost connections
-   with password/md5 authentication.
+   of your operating system. You need to end up with a running
+   Postgres server on your machine that will accept localhost connections.
 
-   Specifically, once you are set up, it should be possible to execute
-   `psql -U <user name> -W -l` with some usre name, enter some password at
-   the prompt, and be shown a list of databases. Depending on your setup, it
-   may also be possible also to simply execute `psql -l`, and so in all of
-   the examples below we drop the `-U <user name>` and `-W` options, but
-   either or both may be necessary any time you invoke postgres
-   command-line programs.
-
-   The USERNAME and password that work for psql are the ones that you need to
-   include in the `.env` file detailed in the next step.
-
-   Finally, once the server is set up and running, pick a database_name, and
-   execute:
+   Specifically, once you are set up, it should be possible to use the command
+   `psql` to connect to a Postgres shell where you can create a database for
+   backscope.
 
    ```bash
-   $ psql    # or perhaps psql -U <user name> -W
-   # The <user name>=# at the beginning of the next line represents the
-   # psql prompt; everything after that represents what you type:
-   <user name>=# CREATE DATABASE <database_name>;
+   psql
+   <username>=# CREATE DATABASE <database_name>;
    CREATE DATABASE
-   <user name>=# \q
-   $
+   <username>=# \q
    ```
 
-   You will need the database_name again for the .env file in the next step.
+3. Set up your environment and initialize the database:
 
-3. Setup your environment and initialize the database
+   This project uses python-dotenv. In order to detect your database
+   username / password, you must create a file called `.env` in the root
+   of your directory containing:
 
-   This project uses python-dotenv. In order to detect your database username / password, you must include a file called .env in the root of your directory. This file should contain:
-
-   /home/path/to/numberscopeFlask/.env
-
-   ```bash
+   ```
    export APP_SETTINGS="config.DevelopmentConfig"
    export DATABASE_URI="postgresql://localhost/<database_name>"
    export SECRET_KEY="Uneccessary for development"
@@ -119,267 +101,47 @@ Set up initial dependencies:
    export POSTGRES_PASSWORD="<user password for psql>"
    ```
 
-   You can see various other configuration options inside ./flaskr/config.py
+   You can see other configuration options inside
+   [the config file](./flaskr/config.py).
 
-   Start your database and setup database access
+4. Configure the database:
 
    ```bash
-   $ python3 manage.py db init # initializes tables inside database
-   $ # Note the previous command will issue a message about editing
-   $ # alembic.ini, which is safe to ignore - the default works fine
-   $ python3 manage.py db migrate # migrate data models found in the project to database
-   $ python3 manage.py db upgrade # Upgrade changes to database
+   python manage.py db init # initializes tables inside database
+   ```
 
-   $ psql -d <database_name>
+  The previous command will issue a message about editing
+  `alembic.ini`, which is safe to ignore. The default works fine.
+   
+   ```bash
+   python manage.py db migrate # migrate data models
+   python manage.py db upgrade # upgrade changes to database
+   psql -d <database_name>
    db=# \d
     Schema |      Name       |   Type   | Owner
    --------+-----------------+----------+-------
-    public | alembic_version | table    | theo
-    public | user            | table    | theo
-    public | user_id_seq     | sequence | theo
-
+    public | alembic_version | table    | <username>
+    public | user            | table    | <username>
+    public | user_id_seq     | sequence | <username>
    db=# \q
    ```
 
-   Currently there is one example user model in flaskr/nscope/models.py
+## Running backscope
 
-### Running the application
-
----
-
-Running this application only deals with flask (backend).
-
-Currently the server is built on development mode.
-
+Option 1:
 ```bash
-$ python3 manage.py runserver
-# Or
-$ export FLASK_APP=flaskr
-$ flask run
+python manage.py runserver
 ```
 
-This should print a series of messages starting with
-"Serving Flask app 'flaskr'" and ending with debugger information. One of these
+Option 2:
+```bash
+export FLASK_APP=flaskr
+flask run
+```
+
+This should print a series of messages. One of these
 messages should be the URL the server is running on, typically
 `http://127.0.0.1:5000/`. To test that the server is working correctly,
 try visiting "<URL>/api/get_oeis_values/A000030/50" (substitute in the server
 URL for "<URL>" -- this should display the first digits of the numbers from
 0 through 49.
-
-## Resetting the database
-
-If you need to clear out the entire database and start from scratch -- for
-example, when pulling a commit that modifies the database schema -- the easiest
-thing to do is delete the database and reinitialize an empty database.
-An example session for this is below; make sure before executing these
-commands that you have activated the virtual environment (venv) for the
-backscope project.
-
-```bash
-# From the top-level backscope directory:
-$ dropdb <database_name>    # or dropdb -U <user name> -W <database_name>
-$ createdb <database_name>  # may need the same options as well
-$ rm -r migrations
-# As above, the next command will give an ignorable message about alembic.ini
-$ python3 manage.py db init
-$ python3 manage.py db migrate
-$ python3 manage.py db upgrade
-```
-
-Now you should again be ready to run the backscope server.
-
-## Endpoints
-
-This section documents all of the endpoints provided by the backscope server.
-All of them return JSON data with the specified keys and values. Also, every
-endpoint includes the key 'id' with value the OEIS id for the sake of verifying
-that it is the data as requested. In case of an OEIS_ID that does not match
-anything in the OEIS, an error string is returned. Note that the angle brackets
-<> in the URLS indicate where subsitutions are made; they should not be present
-in the URLs actually used.
-
-Also note that if any of the requests are made for a given sequence, then the
-back end will in the background obtain all of the data necessary to respond
-to all of the endpoints for future requests concerning that sequence without
-going back to the OEIS. Note that this background work may take an appreciable
-amount of time, especially if the sequence has lots of references within the
-OEIS.
-
-### URL: `api/get_oeis_values/<OEIS_ID>/<COUNT>`
-
-This is the most rapid endpoint, it makes at most one request to the OEIS server
-(and only if the OEIS_ID has not previously been requested). If you are running
-the server to test it on your local host, a full URL would be
-`http://127.0.0.1:5000/api/get_oeis_values/A000030/50` which will return the
-first digits of the numbers 0 through 49.
-
-#### Key: name
-
-A string giving the official name of the OEIS sequence with id OEIS_ID,
-if already known to backscope, or a temporary name if not.
-
-#### Key: values
-
-An array of _strings_ (of digits) giving the first COUNT values of the sequence
-with id OEIS_ID. Since some sequence values correspond to extremely large
-numbers, strings are used to avoid the limitations of any particular numeric
-datatype.
-
-### URL: `api/get_oeis_name_and_values/<OEIS_ID>`
-
-This one is potentially a bit slower than the above URL, as it may make
-an extra request to ensure that the name is correct. If you are running
-the server on your local host, a full URL would be
-`http://127.0.0.1:5000/api/get_oeis_name_and_values/A003173`, which will
-return the nine Heegner numbers and their full name as an OEIS
-sequence (basically, the name describes what a Heegner number is).
-
-#### Key: name
-
-A string giving the official name of the OEIS sequence with id OEIS_ID.
-
-#### Key: values
-
-An array of strings (of digits) giving all values of the sequence with id
-OEIS_ID known to the OEIS.
-
-### URL: `api/get_oeis_metadata/<OEIS_ID>`
-
-A potentially very slow endpoint (if the sequence is unknown to the backscope);
-may make hundreds of requests to the OEIS to generate all of the back
-references to the sequence. If you are running the server on your local
-machine, a full URL would be
-`http://127.0.0.1:5000/api/get_oeis_metadata/A028444` which will show the full
-name of the Busy Beaver sequence, the one text line of sequences it
-references, and the IDs of the ten sequences that refer to it.
-
-#### Key: name
-
-A string giving the official name of the OEIS sequence with id OEIS_ID.
-
-#### Key: xrefs
-
-A string which is the concatenation (separated by newlines) of all of the
-OEIS text "xref" records for the sequence with id OEIS_ID.
-
-#### Key: backrefs
-
-An array of strings giving all OEIS ids that mention the given OEIS_ID.
-
-### URL: `api/get_oeis_factors/<OEIS_ID>/<COUNT>`
-
-This could take a long time. It internally does everything that the endpoint
-`get_oeis_metadata` does, and then once the result is stored in the database
-it proceeds to factor the first `<COUNT>` terms of the sequence (or all of them
-if there are not that many). If you are running the server to test it on your
-local host, a full URL would be
-`http://127.0.0.1:5000/api/get_oeis_factors/A006862/50` which will return the
-factorizations of 1 + the product of the first n primes, for n < 50. The
-first 42 terms will be factored and larger terms will return `no_fac` (since
-they are deemed too large to factor in a reasonable time).
-
-The factorization is performed by pari: `https://pari.math.u-bordeaux.fr/`.
-Previous factorization requests are cached in the database for efficiency.
-Returns the following data:
-
-#### Key: name
-
-A string giving the official name of the OEIS sequence with id OEIS_ID.
-
-#### Key: factors
-
-An array whose indices match the indices of the values of the sequence.
-The format of each entry is a string of the form
-
-`[[p,e],[q,f],...]`
-
-where each entry `[p,e]` represents a factor of the prime p to the power e. If
-an integer is negative, `[-1,1]` is included. If the integer is 1, the
-factorization is `[]` (empty). If the integer is 0, the factorization
-is `[[0,1]]`. Any successful factorization has the property that if you
-multiply 1 times the product of `p^e` for all `[p,e]` in the array, you
-obtain the original value. This format is essentially that supported by pari.
-If the integer exceeds 2^200, the factorization is not attempted and
-the factorization is stored as `no_fac`.
-
-## Other information about the backscope project
-
-### Description of Directories:
-
----
-
-##### migrations
-
-Auto generated
-
-##### manage.py
-
-The main entry point into the application
-
-The main usage from this file is:
-
-```bash
-$ python3 manage.py db init
-$ python3 manage.py db migrate
-$ python3 manage.py db upgrade
-
-$ python3 manage.py runserver
-```
-
-Any other target may be considered for future development
-
-##### api.log
-
-The log file for the flask application
-
-an example logging statment is shown below in python3
-
-```python3
- app.logger.info('%s logged in successfully', user.username)
-```
-
-Logging levels are set in flaskr/config.py
-
-Refer to https://flask.palletsprojects.com/en/1.1.x/logging/ for more information
-
-##### flaskr
-
-Flaskr is the main application. It contains all entry points to the application. \_\_init\_\_.py contains all the application macros.
-
-##### flaskr/\_\_init\_\_.py
-
-The primary file for all application macros
-
-##### flaskr/config.py
-
-The configuration directory for all macro config options. Generally development mode is being used.
-
-##### flaskr/nscope
-
-The nscope api python module. This contains numberscope endpoints and blueprints and models
-
-##### flaskr/nscope/\_\_init\_\_.py
-
-The main entry point to nscope, containing the blueprint for numberscope (imported in \_\_init\_\_.py in flaskr)
-
-##### flaskr/nscope/models.py
-
-Database models. See the example for how to define models as well as https://flask-sqlalchemy.palletsprojects.com/en/2.x/models/
-
-##### flaskr/nscope/views.py
-
-The primary blueprint for numberscope. This is the main application. Note that currently, there is only one endpoint (vuetest). But refer to the documentation within views on how to create a new route.
-
-### WSGI Setup
-
-WSGI is setup on the production server. all wsgi instances and configurations are neglected in the github repository for security.
-
-Documentation is in progress.
-
-On the server, you may manage the status of the application by the systemd entry point for numberscope
-
-```bash
-$ sudo systemctl status numberscopeFlask.service
-```
-
-Numberscope is serving both index.html as well as the numberscope api routes declared inside flask.

--- a/README.md
+++ b/README.md
@@ -6,15 +6,50 @@ This project is licensed under the
 [MIT License](https://opensource.org/licenses/MIT). See the text of the MIT
 License in LICENSE.md.
 
-## Initial Setup
+## Setup
 
-#### Python3 Setup
+### Python
 
-You will need:
+You need a version of Python at least equal to 3.5, but ideally one greater than
+that. (If you don't have Python, install the latest stable version.) By
+installing a version of Python greater than or equal to 3.5, you should get
+the package installer for Python (`pip`) and a working `venv` module for
+creating a virtual environment.
 
-- python3
-- python3-pip
-- virtualenv or anaconda or a virtual python package manager
+To check to see your Python version, issue the following command:
+
+```shell
+python --version
+```
+
+The output should be something like "Python 3.10.8". If you see a message about
+not being able to find Python, or you don't see any output, you need to
+troubleshoot your Python installation.
+
+Depending on how you installed Python, the executable might be named `python3`.
+In that case, issue the following command:
+
+```shell
+python3 --version
+```
+
+To check to see if you have a working `pip`, issue the following
+command (substituting `python3` if necessary):
+
+```shell
+pip --version
+```
+
+You should see something like "pip 22.2.2".
+
+To check to see if you have a working `venv` module, issue the following
+command (substituting `python3` if necessary):
+
+```shell
+python -m venv -h
+```
+
+You should see help for the `venv` module.
 
 Set up initial dependencies:
 

--- a/README.md
+++ b/README.md
@@ -39,15 +39,6 @@ In that case, issue the following command:
 python3 --version
 ```
 
-To check to see if you have a working `pip`, issue the following
-command (substituting `python3` if necessary):
-
-```shell
-pip --version
-```
-
-You should see something like "pip 22.2.2".
-
 To check to see if you have a working `venv` module, issue the following
 command (substituting `python3` if necessary):
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ backscope is [Numberscope's](https://numberscope.colorado.edu) back end. It is
 responsible for getting sequences and other data from the [On-Line Encyclopedia
 of Integer Sequences](https://oeis.org).
 
-## Setup
+## Set up backscope
 
-### Python
+### Install Python
 
 You need a version of Python at least equal to 3.5, but ideally one greater than
 that. (If you don't have Python, install the latest stable version.) By
@@ -126,7 +126,7 @@ You should see help for the `venv` module.
    db=# \q
    ```
 
-## Running backscope
+## Run backscope
 
 Option 1:
 ```bash

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ of Integer Sequences](https://oeis.org).
 
 ### Install Python
 
-You need a version of Python at least equal to 3.5, but ideally one greater than
-that. (If you don't have Python, install the latest stable version.) By
-installing a version of Python greater than or equal to 3.5, you should get
-the package installer for Python (`pip`) and a working `venv` module for
-creating a virtual environment.
+You need a version of Python at least equal to 3.5. (If you don't have
+Python, install the latest stable version.) By installing a version of
+Python greater than or equal to 3.5, you should get the package
+installer for Python (`pip`) and a working `venv` module for creating a
+virtual environment.
 
 To check to see your Python version, issue the following command:
 

--- a/doc/api_endpoints.md
+++ b/doc/api_endpoints.md
@@ -1,0 +1,115 @@
+# API endpoints
+
+As of 2022-11-01, this document might be outdated.
+
+This documents all of the endpoints provided by the backscope server.
+All of them return JSON data with the specified keys and values. Also, every
+endpoint includes the key 'id' with value the OEIS id for the sake of verifying
+that it is the data as requested. In case of an OEIS_ID that does not match
+anything in the OEIS, an error string is returned. Note that the angle brackets
+<> in the URLS indicate where subsitutions are made; they should not be present
+in the URLs actually used.
+
+Also note that if any of the requests are made for a given sequence, then the
+back end will in the background obtain all of the data necessary to respond
+to all of the endpoints for future requests concerning that sequence without
+going back to the OEIS. Note that this background work may take an appreciable
+amount of time, especially if the sequence has lots of references within the
+OEIS.
+
+### URL: `api/get_oeis_values/<OEIS_ID>/<COUNT>`
+
+This is the most rapid endpoint, it makes at most one request to the OEIS server
+(and only if the OEIS_ID has not previously been requested). If you are running
+the server to test it on your local host, a full URL would be
+`http://127.0.0.1:5000/api/get_oeis_values/A000030/50` which will return the
+first digits of the numbers 0 through 49.
+
+#### Key: name
+
+A string giving the official name of the OEIS sequence with id OEIS_ID,
+if already known to backscope, or a temporary name if not.
+
+#### Key: values
+
+An array of _strings_ (of digits) giving the first COUNT values of the sequence
+with id OEIS_ID. Since some sequence values correspond to extremely large
+numbers, strings are used to avoid the limitations of any particular numeric
+datatype.
+
+### URL: `api/get_oeis_name_and_values/<OEIS_ID>`
+
+This one is potentially a bit slower than the above URL, as it may make
+an extra request to ensure that the name is correct. If you are running
+the server on your local host, a full URL would be
+`http://127.0.0.1:5000/api/get_oeis_name_and_values/A003173`, which will
+return the nine Heegner numbers and their full name as an OEIS
+sequence (basically, the name describes what a Heegner number is).
+
+#### Key: name
+
+A string giving the official name of the OEIS sequence with id OEIS_ID.
+
+#### Key: values
+
+An array of strings (of digits) giving all values of the sequence with id
+OEIS_ID known to the OEIS.
+
+### URL: `api/get_oeis_metadata/<OEIS_ID>`
+
+A potentially very slow endpoint (if the sequence is unknown to the backscope);
+may make hundreds of requests to the OEIS to generate all of the back
+references to the sequence. If you are running the server on your local
+machine, a full URL would be
+`http://127.0.0.1:5000/api/get_oeis_metadata/A028444` which will show the full
+name of the Busy Beaver sequence, the one text line of sequences it
+references, and the IDs of the ten sequences that refer to it.
+
+#### Key: name
+
+A string giving the official name of the OEIS sequence with id OEIS_ID.
+
+#### Key: xrefs
+
+A string which is the concatenation (separated by newlines) of all of the
+OEIS text "xref" records for the sequence with id OEIS_ID.
+
+#### Key: backrefs
+
+An array of strings giving all OEIS ids that mention the given OEIS_ID.
+
+### URL: `api/get_oeis_factors/<OEIS_ID>/<COUNT>`
+
+This could take a long time. It internally does everything that the endpoint
+`get_oeis_metadata` does, and then once the result is stored in the database
+it proceeds to factor the first `<COUNT>` terms of the sequence (or all of them
+if there are not that many). If you are running the server to test it on your
+local host, a full URL would be
+`http://127.0.0.1:5000/api/get_oeis_factors/A006862/50` which will return the
+factorizations of 1 + the product of the first n primes, for n < 50. The
+first 42 terms will be factored and larger terms will return `no_fac` (since
+they are deemed too large to factor in a reasonable time).
+
+The factorization is performed by pari: `https://pari.math.u-bordeaux.fr/`.
+Previous factorization requests are cached in the database for efficiency.
+Returns the following data:
+
+#### Key: name
+
+A string giving the official name of the OEIS sequence with id OEIS_ID.
+
+#### Key: factors
+
+An array whose indices match the indices of the values of the sequence.
+The format of each entry is a string of the form
+
+`[[p,e],[q,f],...]`
+
+where each entry `[p,e]` represents a factor of the prime p to the power e. If
+an integer is negative, `[-1,1]` is included. If the integer is 1, the
+factorization is `[]` (empty). If the integer is 0, the factorization
+is `[[0,1]]`. Any successful factorization has the property that if you
+multiply 1 times the product of `p^e` for all `[p,e]` in the array, you
+obtain the original value. This format is essentially that supported by pari.
+If the integer exceeds 2^200, the factorization is not attempted and
+the factorization is stored as `no_fac`.

--- a/doc/directory_descriptions.md
+++ b/doc/directory_descriptions.md
@@ -1,0 +1,79 @@
+# Description of directories
+
+As of 2022-11-01, this document might be outdated.
+
+##### migrations
+
+Auto generated
+
+##### manage.py
+
+The main entry point into the application
+
+The main usage from this file is:
+
+```bash
+$ python3 manage.py db init
+$ python3 manage.py db migrate
+$ python3 manage.py db upgrade
+
+$ python3 manage.py runserver
+```
+
+Any other target may be considered for future development
+
+##### api.log
+
+The log file for the flask application
+
+an example logging statment is shown below in python3
+
+```python3
+ app.logger.info('%s logged in successfully', user.username)
+```
+
+Logging levels are set in flaskr/config.py
+
+Refer to https://flask.palletsprojects.com/en/1.1.x/logging/ for more information
+
+##### flaskr
+
+Flaskr is the main application. It contains all entry points to the application. \_\_init\_\_.py contains all the application macros.
+
+##### flaskr/\_\_init\_\_.py
+
+The primary file for all application macros
+
+##### flaskr/config.py
+
+The configuration directory for all macro config options. Generally development mode is being used.
+
+##### flaskr/nscope
+
+The nscope api python module. This contains numberscope endpoints and blueprints and models
+
+##### flaskr/nscope/\_\_init\_\_.py
+
+The main entry point to nscope, containing the blueprint for numberscope (imported in \_\_init\_\_.py in flaskr)
+
+##### flaskr/nscope/models.py
+
+Database models. See the example for how to define models as well as https://flask-sqlalchemy.palletsprojects.com/en/2.x/models/
+
+##### flaskr/nscope/views.py
+
+The primary blueprint for numberscope. This is the main application. Note that currently, there is only one endpoint (vuetest). But refer to the documentation within views on how to create a new route.
+
+### WSGI Setup
+
+WSGI is setup on the production server. all wsgi instances and configurations are neglected in the github repository for security.
+
+Documentation is in progress.
+
+On the server, you may manage the status of the application by the systemd entry point for numberscope
+
+```bash
+$ sudo systemctl status numberscopeFlask.service
+```
+
+Numberscope is serving both index.html as well as the numberscope api routes declared inside flask.

--- a/doc/resetting-the-database.md
+++ b/doc/resetting-the-database.md
@@ -1,0 +1,17 @@
+# Resetting the database
+
+If you need to clear out the entire database and start from scratch -- for
+example, when pulling a commit that modifies the database schema -- the easiest
+thing to do is delete the database and reinitialize an empty database.
+An example session for this is below; make sure before executing these
+commands that you have activated the virtual environment
+(`source .venv/bin/activate`) for the backscope project.
+
+```bash
+dropdb <database_name>
+createdb <database_name>
+rm -rf migrations
+python manage.py db init
+python manage.py db migrate
+python manage.py db upgrade
+```


### PR DESCRIPTION
This PR:

- updates/improves the README
- removes any OS or distribution-specific instructions about Postgres (we're keeping it deliberately vague so that the user has to figure out their specific setup rather than just copying and pasting commands from the README, which might lead to issues with their setup)
- moves some of the info that was in the README into docs in the doc dir