### PR TITLE
fix: Avoid race conditions with multiple requests for same sequence

### DIFF
--- a/flaskr/nscope/models.py
+++ b/flaskr/nscope/models.py
@@ -36,9 +36,11 @@ class Sequence(db.Model):
     # The following is called the "offset" in the OEIS, but that is a
     # Postgres reserved word, so we use a different name.
     shift = db.Column(db.Integer, unique=False, nullable=False, default=0)
-    values = db.Column(db.ARRAY(db.String), unique=False, nullable=False)
+    values = db.Column(db.ARRAY(db.String), unique=False, nullable=True)
+    values_requested = db.Column(db.Boolean, nullable=False, default=False)
     raw_refs = db.Column(db.String, unique=False, nullable=True)
     backrefs = db.Column(db.ARRAY(db.String), unique=False, nullable=True)
+    meta_requested = db.Column(db.Boolean, nullable=False, default=False)
     # Sadly, multidimensional arrays can't vary in dimension
     # so we store factorization arrays as strings
     factors = db.Column(db.ARRAY(db.String), unique=False, nullable=True)


### PR DESCRIPTION
  Decouples the fetching of metadata from values and factoring, and
  allows each of these steps to occur sequentially or asynchronously
  (except factoring has to occur after values). Adds booleans to the
  database scheme to keep track of whether the value-fetching or
  metadata-fetching steps have been initiated, thereby avoiding
  race conditions

  Resolves #66.

NOTE: This PR modifies the database schema! Therefore to test it, it is necessary to delete and reinitialize your database. The directions for doing so are in `doc/resetting-the-database.md`.