### PR TITLE
Rename and document clear-database command

### DIFF
--- a/doc/resetting-the-database.md
+++ b/doc/resetting-the-database.md
@@ -1,17 +1,42 @@
 # Resetting the database
 
-If you need to clear out the entire database and start from scratch -- for
-example, when pulling a commit that modifies the database schema -- the easiest
-thing to do is delete the database and reinitialize an empty database.
-An example session for this is below; make sure before executing these
-commands that you have activated the virtual environment
-(`source .venv/bin/activate`) for the backscope project.
+## Clear the stored data, but keep the database structure
 
-```bash
-dropdb <database_name>
-createdb <database_name>
-rm -rf migrations
-flask db init
-flask db migrate
-flask db upgrade
-```
+Backscope caches data about every sequence that's been requested. You may find yourself in a situation where that stored data is causing a problem. For example:
+
+- You're working on code that only runs when Backscope downloads data from the OEIS. To try your code on a particular sequence, you need to make sure the sequence isn't cached already.
+- A bug in your code has left certain data flagged, incorrectly, as a download in progress. Backscope won't clear the flag until the download finishes, and it won't start the download if the flag is set.
+
+In a situation like this, you don't need to wipe out the whole database structure; it's enough to clear the data stored inside that structure. Here's how to do it:
+
+1. Activate Backscope's virtual environment, if it's not active already.
+   + For example, if you're using [`venv`](https://docs.python.org/3/library/venv.html) and you've put the virtual environment in `.venv`, call `source .venv/bin/activate`.
+2. Clear the database by calling `flask clear-database`.
+
+:warning: **Beware:** this will clear the database named by the `POSTGRES_DB` variable in the `.env` file.
+
+## Wipe out the whole database structure and build a fresh database from scratch
+
+More rarely, you may find yourself in a situation where the structure of the database is causing a problem, which can't be solved just by clearing the contents of the database. For example:
+
+- You just wrote or checked out a version of Backscope that uses a different database schema.
+
+In a situation like this, it's often easiest to wipe out the whole database structure and build a new database from scratch, as if you're setting up Backscope for the first time. Here's how to do it:
+
+1. Activate Backscope's virtual environment, if it's not active already.
+   + For example, if you're using [`venv`](https://docs.python.org/3/library/venv.html) and you've put the virtual environment in `.venv`, call `source .venv/bin/activate`.
+2. Erase every trace of the database from your global PostgreSQL instance by calling:
+   ```bash
+   dropdb <database name>
+   ```
+   Typically, `<database name>` should match the `POSTGRES_DB` variable in the `.env` file.
+3. Forget local information about past migrations by removing or renaming the `migrations` folder in the top level of the Backscope repository.
+4. Create a new database and furnish it with the Backscope database structure by calling:
+   ```bash
+   createdb <database name>
+   flask db init
+   flask db migrate
+   flask db upgrade
+   ```
+
+:warning: **Beware:** steps 2–3 will wipe out the entire structure and contents of the database `<database name>`.

--- a/doc/resetting-the-database.md
+++ b/doc/resetting-the-database.md
@@ -31,6 +31,7 @@ In a situation like this, it's often easiest to wipe out the whole database stru
    ```
    Typically, `<database name>` should match the `POSTGRES_DB` variable in the `.env` file.
 3. Forget local information about past migrations by removing or renaming the `migrations` folder in the top level of the Backscope repository.
+   + For example, put `migrations` in the trash by calling `gio trash migrations` on Ubuntu 18.04 or newer.
 4. Create a new database and furnish it with the Backscope database structure by calling:
    ```bash
    createdb <database name>

--- a/flaskr/__init__.py
+++ b/flaskr/__init__.py
@@ -69,7 +69,7 @@ def create_app(environment=None):
     Migrate(app, db)
 
     # Add a command line interface to the application
-    app.cli.add_command(init_db_command)
+    app.cli.add_command(clear_database_command)
 
     # The nscope endpoint application
     from flaskr import nscope
@@ -82,13 +82,12 @@ def create_app(environment=None):
     return app
 
 
-def init_db():
+def clear_database():
     db.drop_all()
     db.create_all()
 
-@click.command("init-db")
+@click.command("clear-database")
 @with_appcontext
-def init_db_command():
-    init_db()
-    click.echo("Initialized Database")
-
+def clear_database_command():
+    clear_database()
+    click.echo("Database cleared")

--- a/flaskr/__init__.py
+++ b/flaskr/__init__.py
@@ -3,7 +3,7 @@ Init file (creates app and database)
 """
 
 import os
-from flask import Flask
+from flask import Flask, current_app
 import click
 from flask.cli import with_appcontext
 from flask_cors import CORS
@@ -89,5 +89,14 @@ def clear_database():
 @click.command("clear-database")
 @with_appcontext
 def clear_database_command():
+    if current_app.config['PRODUCTION']:
+      confirm = input(
+        'Backscope is running in production mode. Are you sure you want to '
+        'clear the production database? Enter "yes" to confirm, or any other '
+        'string to abort: '
+      )
+      if not (confirm == 'yes'):
+        click.echo("No action taken")
+        return
     clear_database()
     click.echo("Database cleared")

--- a/flaskr/config.py
+++ b/flaskr/config.py
@@ -39,8 +39,9 @@ class Config:
     DOC_USERNAME = 'api'
     DOC_PASSWORD = 'password'
     
-    TESTING = False
     DEBUG = False
+    TESTING = False
+    PRODUCTION = False
 
 
 class DevConfig(Config):
@@ -57,7 +58,7 @@ class TestConfig(Config):
 
 
 class ProdConfig(Config):
-    pass
+    PRODUCTION = True
 
 
 config = {

--- a/flaskr/nscope/test/abstract_endpoint_test.py
+++ b/flaskr/nscope/test/abstract_endpoint_test.py
@@ -1,6 +1,6 @@
 import unittest
 import sys
-from flaskr import create_app, db
+from flaskr import create_app, db, clear_database
 import flaskr.nscope.views as views
 
 
@@ -31,7 +31,7 @@ class AbstractEndpointTest(unittest.TestCase):
     self.app = create_app('testing')
     self.ctx = self.app.app_context()
     with self.ctx:
-      db.create_all()
+      clear_database()
     
     # put mid-test messages on a new line
     if self.verbose:


### PR DESCRIPTION
Document the command that clears the database. It's been renamed `clear-database`, since the old name (`init-db`) was confusing.

#### Notable features

- The instructions for resetting the database are a lot wordier now. Is it too much?
- The clear-database command asks for confirmation if Backscope is running in production mode. To support this, I've added a `PRODUCTION` flag to the app config.
- In the instructions for wiping out the database structure, I've removed the suggestion to use `rm -rf` to get rid of the migrations folder. In my opinion, someone who should do that won't need the suggestion, and someone who needs the suggestion shouldn't do it.