### PR TITLE
Test `get_oeis_values` response for nonexistent sequence

### DIFF
--- a/flaskr/nscope/test/test_get_commit.py
+++ b/flaskr/nscope/test/test_get_commit.py
@@ -2,12 +2,12 @@ import unittest
 import flaskr.nscope.test.abstract_endpoint_test as abstract_endpoint_test
 import subprocess # for calling git
 
-class TestGetHash(abstract_endpoint_test.AbstractEndpointTest):
-  endpoint = "http://127.0.0.1:5000/api/get_commit"
+class TestGetCommit(abstract_endpoint_test.AbstractEndpointTest):
+  endpoint = "http://localhost:5000/api/get_commit"
   
   #   should return the most recent hash
   short_hash = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'])
   short_hash = str(short_hash, "utf-8").strip()
-  expected_response_json = {
+  expected_response = {
     'short_commit_hash': short_hash,
   }

--- a/flaskr/nscope/test/test_get_oeis_values.py
+++ b/flaskr/nscope/test/test_get_oeis_values.py
@@ -9,7 +9,7 @@ class TestGetOEISValuesWithoutShift(abstract_endpoint_test.AbstractEndpointTest)
   # - it has zero shift, so the test can pass even if the shift defaults to zero
   # - it currently has small values and few references, which speeds up the
   #   background work triggered by the request
-  expected_response_json = {
+  expected_response = {
     'id': 'A153080',
     'name': 'A153080 [name not yet loaded]',
     'values': {
@@ -43,7 +43,7 @@ class TestGetOEISValues(abstract_endpoint_test.AbstractEndpointTest):
   #   changed to the actual value
   # - it currently has small values and few references, which speeds up the
   #   background work triggered by the request
-  expected_response_json = {
+  expected_response = {
     'id': 'A321580',
     'name': 'A321580 [name not yet loaded]',
     'values': {

--- a/flaskr/nscope/test/test_lookup_errors.py
+++ b/flaskr/nscope/test/test_lookup_errors.py
@@ -1,0 +1,16 @@
+import unittest
+import flaskr.nscope.test.abstract_endpoint_test as abstract_endpoint_test
+
+
+# According to the OEIS wiki, "The A-number A000000 is inadmissible". That
+# should make A000000 a relatively stable example of a non-existent sequence.
+#
+#   https://oeis.org/wiki/A-numbers
+#
+class TestNonexistentSequence(abstract_endpoint_test.AbstractEndpointTest):
+  endpoint = "http://localhost:5000/api/get_oeis_values/A000000/12"
+  expected_response = "Error: B-file for ID 'A000000' not found in OEIS."
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Current pull request

Add a test to make sure that `get_oeis_values` gives the expected error response when you ask for a sequence that's not in the OEIS, rather than hanging or crashing.

Right now, the error response is text rather than JSON, so I extended `AbstractEndpointTest` to accommodate this. The parameter `expected_response_json` has been replaced with `expected_response`, which must be a dictionary or a string. If it's a dictionary, it's compared against `response.json`. If it's a string, it's compared against `response.text`.

### Future directions

I think tests for the other lookup errors will have to wait for the mock OEIS, because they can't be triggered at will.

To streamline error handling in the front end, maybe we should make the error signal more convenient to detect. For example, we could use HTTP status codes to indicate whether there was an error, or we could make both normal and error responses JSON with an error flag key.