### PR TITLE
fix: Determine git revision hash once at startup

### DIFF
--- a/flaskr/nscope/views.py
+++ b/flaskr/nscope/views.py
@@ -13,7 +13,6 @@ import cypari2
 from cypari2.convert import gen_to_python
 import re
 import requests
-import subprocess # for calling git
 
 
 executor = Executor()
@@ -327,13 +326,8 @@ def get_oeis_factors(oeis_id, num_elements):
 @bp.route("/api/get_commit", methods=["GET"])
 def get_git_commit():
     """ Returns the short git hash for the current build of backscope
-        as provided by the command
-        git rev-parse --short HEAD
-        thanks to: https://stackoverflow.com/questions/14989858/get-the-current-git-hash-in-a-python-script/
+        (as determined at startup in flaskr/__init__.py)
     """
-    short_hash = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'], encoding='utf8')
     return jsonify({
-        'short_commit_hash': short_hash.strip()
+        'short_commit_hash': current_app.config['git_revision_hash']
     })
-
-

--- a/server/production.sh
+++ b/server/production.sh
@@ -2,4 +2,5 @@
 cd /home/scope/repos/backscope &&
 source .venv/bin/activate &&
 sh tools/install-requirements.sh &&
+export GIT_REVISION_HASH=$(git rev-parse --short HEAD) &&
 gunicorn --workers 3 --bind unix:/home/scope/repos/backscope/backscope.sock -m 777 wsgi:app


### PR DESCRIPTION
  This way, the server continues to supply the correct git revision hash
  even if the code changes after startup. Unless overridden by an
  environment variable, simply uses `git rev-parse --short HEAD`. In
  production, uses the environment override because the eventual flask
  process doesn't have the correct permissions to perform the git
  command.

  Resolves #108.