### PR TITLE
fix: Hot fix for #113 in production

### DIFF
--- a/server/production.sh
+++ b/server/production.sh
@@ -2,5 +2,5 @@
 cd /home/scope/repos/backscope &&
 source .venv/bin/activate &&
 sh tools/install-requirements.sh &&
-export GIT_REVISION_HASH=$(git rev-parse --short HEAD) &&
+export GIT_REVISION_HASH=$(sudo -u scope git rev-parse --short HEAD) &&
 gunicorn --workers 3 --bind unix:/home/scope/repos/backscope/backscope.sock -m 777 wsgi:app


### PR DESCRIPTION
#113 as merged caused the backscope in production to crash, as it was trying to get the git revision of the backscope software from the wrong userid. This PR represents precisely the hot fix **currently installed in production** under which it appears to be running fine. So merging this (which @katestange  please take a look and do as soon as convenient, since @Vectornaut is swamped) will simply bring the repo to match what is currently running in production.