### PR TITLE
feat: `flask test -v` sets maxDiff to None

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -27,4 +27,6 @@ def test(verbosity, start_dir, pattern, top_level_dir):
     pattern=pattern,
     top_level_dir=top_level_dir
   )
+  if verbosity > 0:
+    unittest.TestCase.maxDiff = None
   unittest.TextTestRunner(verbosity=verbosity+1).run(test_suite)


### PR DESCRIPTION
  This causes the output for any test failures to show full diffs, however
  large they may be (only when the -v flag is specified).
  Resolves #116.