### PR TITLE
fix: Production hot fix to install gunicorn

### DIFF
--- a/server/production.sh
+++ b/server/production.sh
@@ -2,5 +2,6 @@
 cd /home/scope/repos/backscope &&
 source .venv/bin/activate &&
 sh tools/install-requirements.sh &&
+pip install gunicorn &&
 export GIT_REVISION_HASH=$(sudo -u scope git rev-parse --short HEAD) &&
 gunicorn --workers 3 --bind unix:/home/scope/repos/backscope/backscope.sock -m 777 wsgi:app


### PR DESCRIPTION
The python package gunicorn is only needed in production (but it is required in that setting). Hence there is nothing in requirements.txt etc that installs it. This means that when .venv is blown away (such as migrating to a new server, recovering from a failure, or simply testing full installation or cleaning out an old .venv that has accumulated unneeded code), production fails unless gunicorn is installed. (And indeed, that is exactly what happened when #109 was installed in production.) This PR adds a line to server/production.sh to install gunicorn, and precisely reflects the hot fix that is already present and running in production to cope with the situation.

In other words, merging this and installing in production will result in no change to current production, and should prevent future such failures when .venv has to be reset.
