### PR TITLE
chore: Bump cypari2 to 2.1.5 and document new Python requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ also be tailored to other Linux distributions or other operating systems.)
    `github.com/numberscope/backscope`. Switch to the top-level directory
    of the clone.
 2. Install prerequisites:
-   + Python 3 (>= version 3.8, although older versions may work)
+   + Python 3 (>= version 3.9)
    + The Python 3 dev package
    + A Python 3 package for creating virtual environments
    + A full installation of pari-gp (including all metadata files — you might

--- a/doc/install-ubuntu.md
+++ b/doc/install-ubuntu.md
@@ -164,7 +164,7 @@ virtual environment.
 
   If/when this seems to have succeeded, execute `python3.9 --version`. It
   should succeed and display a version number like 3.9.13 (in any case,
-  starting with 3.9.
+  starting with 3.9).
 
 In all of the remaining commands in this guide, substitute one of `python`,
 `python3`, or `python3.9` for `[PYEXEC]` wherever it appears in a command,

--- a/doc/install-ubuntu.md
+++ b/doc/install-ubuntu.md
@@ -1,12 +1,15 @@
 # Installing backscope on Ubuntu
 
-These step-by-step instructions are for (a fresh installation of the latest)
-Ubuntu, a Linux distribution. They assume no prior knowledge concerning
-any of the software packages or tools that backscope depends on.
+These step-by-step instructions are for Ubuntu, a Linux distribution. They
+assume no prior knowledge concerning any of the software packages or tools
+that backscope depends on. The instructions are generally tuned for a fresh
+installation of the latest long-term support version of Ubuntu, although
+there is some additional material for coping with versions as far back as
+Ubuntu 20.04.
 
 If you are trying to run backscope on a different Linux distribution or on a
-different operating system, you will need to modify some of the commands and/or
-steps. There are some comments on modifications you might need to make
+different operating system, you will likely need to modify some of the commands
+and/or steps. There are some comments on modifications you might need to make
 within the steps below. You may need to become more familiar with the details
 of the various software packages needed in order to do this.
 
@@ -72,8 +75,8 @@ If in the first case you see some output about the version number, and in the
 second you see information about the factorial function, then you have likely
 installed the package correctly. If the first succeeds but the second fails,
 for example on a non-Ubuntu distribution, check to see if your package
-manager has separated documentation for PARI/GP into a separately-installable
-package and if so, install that as well.
+manager has separated documentation for PARI/GP into an
+independently-installable package and if so, install that as well.
 
 ### Install libpari-dev, which contains a file needed to install cypari2
 
@@ -112,41 +115,67 @@ sudo apt install build-essential autoconf
 
 ### Install Python 3
 
-You need a version of Python at least equal to 3.5. (If you don't have
+You need a version of Python at least equal to 3.9. (If you don't have
 Python, install the latest stable version.) By installing a version of
-Python greater than or equal to 3.5, you should get the package
+Python greater than or equal to 3.9, you should get the package
 installer for Python (`pip`) and a working `venv` module for creating a
 virtual environment.
 
-To check your current Python version, issue the following command:
+* To check your current Python version, issue the following command:
 
-```shell
-python --version
-```
+  ```shell
+  python --version
+  ```
 
-The output should be something like "Python 3.10.8", but possibly with
-different numbers after the "3.". If you see a message about
-not being able to find Python, or if you don't see any output, you need to
-troubleshoot your Python installation.
+  The output should be something like "Python 3.10.8", but possibly with
+  different numbers after the "3.". If you see a message about
+  not being able to find Python, or if you don't see any output, you need to
+  troubleshoot your Python installation.
 
-Depending on how you installed Python, the executable might be named
-`python3`. It's also possible that `python --version` reports a version
-number that starts with "2" -- that won't be usable by backscope. So in
-either case, try the following command:
+* Depending on how you installed Python, the executable might be named
+  `python3`. It's also possible that `python --version` reports a version
+  number that starts with "2" -- that won't be usable by backscope. So in
+  either case, try the following command:
 
-```shell
-python3 --version
-```
+  ```shell
+  python3 --version
+  ```
+  Again, if this command executes successfully and reports a python version
+  greater than or equal to 3.9, you can proceed.
 
-In all the remaining commands, substitute either `python` or `python3` for
-`[PYEXEC]` depending on which of the above worked.
+* In the particular case of Ubuntu 20.04, you will likely find that even when
+  Python is fully updated, `python3 --version` reports a version number
+  3.8.x for some final number x. It won't be possible to install backscope
+  with this Python. However, a Python 3.9 package is available for this
+  distribution. Try
+
+  ```shell
+  sudo apt install python3.9
+  ```
+
+  If that doesn't work, you may need to add the community-based "Universe"
+  repository. You can do that as follows, and then retry the command just
+  above:
+
+  ```shell
+  sudo add-apt-repository universe
+  sudo apt update
+  ```
+
+  If/when this seems to have succeeded, execute `python3.9 --version`. It
+  should succeed and display a version number like 3.9.13 (in any case,
+  starting with 3.9.
+
+In all of the remaining commands in this guide, substitute one of `python`,
+`python3`, or `python3.9` for `[PYEXEC]` wherever it appears in a command,
+depending on which of the above options worked.
 
 
 ### Install python3-dev, required for cypari2
 
 This is the Python development package. We need it to compile cypari2.
 On ubuntu, you can install this package via the following command
-(regardless of whether you are invoking Python via `python` or `python3`).
+(regardless of how you are invoking Python).
 
 ```
 sudo apt install python3-dev
@@ -173,7 +202,7 @@ instead.)
 
 If this command displays anything other than `OK` (such as `False` or an error
 message) then your distribution is lacking these header files. This sort of
-error should not occur on Ubuntu 20 or Ubuntu 22 if the above installation
+error should not occur on Ubuntu 20.04 or later if the above installation
 commands have all executed successfully.
 
 
@@ -230,9 +259,9 @@ and pick up the process, make sure to re-activate the virtual environment
 by re-issuing the `source .venv/bin/activate` command in the top-level
 directory of your backscope clone. Note also that once the virtual
 environment is activated, the `python` command will invoke the proper
-version of `python`, so you no longer need to worry about whether you
-need to call `python3` or `python`. Hence, the remaining instructions
-all just use `python`.
+version of Python, so you no longer need to worry about whether you
+need to call `python` or `python3` or `python3.9`. Hence, the remaining
+instructions all just use `python`.
 
 ### Install dependencies
 
@@ -243,9 +272,11 @@ This installs all of backscope's dependencies listed in
 sh tools/install-requirements.sh
 ```
 
-Expect the step that compiles `cypari2` to take a significant amount of time.
-If it fails saying that a compile command was killed, you may not have
-enough memory available; you probably need at least 4GB.
+Expect the step that compiles `cypari2` (if there is one; it will depend
+on whether there is a precompiled version available tailored to your
+setup) to take a significant amount of time. If it fails saying that a
+compile command was killed, you may not have enough memory available;
+you probably need at least 4GB.
 
 ### Install and configure PostgreSQL
 

--- a/requirements-freeze.txt
+++ b/requirements-freeze.txt
@@ -3,7 +3,7 @@ blinker==1.7.0
 certifi==2024.2.2
 charset-normalizer==3.3.2
 click==8.1.7
-cypari2==2.1.3
+cypari2==2.1.5
 cysignals==1.11.4
 Flask==3.0.3
 Flask-Cors==4.0.0


### PR DESCRIPTION
This will reconcile development and production versions, while maintaining the ability to develop on Ubuntu 20.04.
