### PR TITLE
Fix metadata search bug from logging overhaul

### DIFF
--- a/flaskr/nscope/views.py
+++ b/flaskr/nscope/views.py
@@ -89,7 +89,7 @@ def fetch_metadata(oeis_id):
     db.session.commit()
     # Now grab the data
     search_params = {'q': seq.id, 'fmt': 'json'}
-    r = oeis_get('/search', search_params)
+    r = oeis_get('/search', search_params).json()
     if r['results'] != None: # Found some metadata
         backrefs = []
         target_number = int(seq.id[1:])
@@ -105,7 +105,7 @@ def fetch_metadata(oeis_id):
                 saw += 1
             if saw < matches:
                 search_params['start'] = saw
-                r = oeis_get('\search', search_params).json()
+                r = oeis_get('/search', search_params).json()
                 if r['results'] == None:
                     break
         seq.backrefs = backrefs


### PR DESCRIPTION
This fixes bug #121 by correcting some small mistakes I made in #111, which broke `fetch_metadata`.

The mistakes weren't caught during review because the automated tests don't cover background work yet, and I didn't think to check manually that the sequence name and other metadata were showing up eventually.

My takeaway: when we do manual tests during pull request review, we should check that sequence names are showing up, as a quick way to verify that metadata is being fetched successfully.