### PR TITLE
fix: Update format for search by ID

### DIFF
--- a/flaskr/nscope/test/test_wrong_response_type.py
+++ b/flaskr/nscope/test/test_wrong_response_type.py
@@ -15,7 +15,7 @@ class TestUnavailableValuesInNameAndValues(abstract_mock_oeis_test.AbstractMockO
 class TestUnavailableSearchInNameAndValues(abstract_mock_oeis_test.AbstractMockOEISTest):
   search_available = False
   endpoint = 'http://localhost:5000/api/get_oeis_name_and_values/A153080'
-  expected_response = 'Error: 503 Server Error: SERVICE UNAVAILABLE for url: http://localhost:5001/search?id=A153080&fmt=json'
+  expected_response = 'Error: 503 Server Error: SERVICE UNAVAILABLE for url: http://localhost:5001/search?q=id%3AA153080&fmt=json'
 
 class TestUnavailableSearch(abstract_mock_oeis_test.AbstractMockOEISTest):
   search_available = False

--- a/flaskr/nscope/views.py
+++ b/flaskr/nscope/views.py
@@ -406,7 +406,7 @@ def get_oeis_name_and_values(oeis_id):
     # Now get the name
     seq = find_oeis_sequence(valid_oeis_id)
     if not seq.name or seq.name == placeholder_name(oeis_id):
-        search_response = oeis_get('/search', {'id': oeis_id, 'fmt': 'json'})
+        search_response = oeis_get('/search', {'q': f'id:{oeis_id}', 'fmt': 'json'})
         if isinstance(search_response, Exception):
             return f"Error: {search_response}"
         if search_response['results'] != None:


### PR DESCRIPTION
  [This is simply a single-commit version of #135.]
  Corrects the search query in get_oeis_name_and_values. The Requests
  library automatically URL-encodes the query, so the : in the query
  gets sent as %3A.

  Resolves #133.