### PR TITLE
fix: Attempt to catch cypari factoring errors

### DIFF
--- a/doc/server-administration.md
+++ b/doc/server-administration.md
@@ -63,9 +63,12 @@ sudo systemctl stop numberscope
 ### Accessing `numberscope` logs
 
 You can see the standard error output of the backscope process via
-`sudo journalctl -u backscope`. However, most diagnostic output is directed to
+`sudo journalctl -u numberscope`. However, most diagnostic output is directed to
 backscope's own rotating log files, in the `~scope/repos/backscope/logs`
 directory.
+
+When trying to figure out what is going on with the server, it may also be
+helpful to look at the `nginx` logs, in the `/var/log/nginx` directory.
 
 ## Updating the server to a new version of backscope
 

--- a/flaskr/nscope/views.py
+++ b/flaskr/nscope/views.py
@@ -315,11 +315,17 @@ def fetch_factors(oeis_id, num_elements = -1):
         if val == 1:
             fac = []
         elif abs(val) <= 2**200: # Arbitrary limit; a timeout would be better
+            log = current_app.structlogger.bind(tags=[])
             fac = []
-            # elements are arrays [p, e] for factor p^e
-            # including [-1,1] for negative numbers
-            # and [0,1] for zero
-            fac = gen_to_python(pari(val).factor())
+            try:
+                # elements are arrays [p, e] for factor p^e
+                # including [-1,1] for negative numbers
+                # and [0,1] for zero
+                fac = gen_to_python(pari(val).factor())
+            except Exception as ex:
+                log = log.bind(exception = ex, value = val)
+                log.warn('Cython factoring error')
+                fac = 'no_fac'
         else:
             fac = 'no_fac'
         factors.append(str(fac).replace(" ",""));


### PR DESCRIPTION
  It appears in production that cypari is crashing, but the backtrace
  is pretty uninformative. And there is not currently a known way to
  reproduce the error when running locally. So this commit wraps the
  factoring call to cypari in a try-except and then attempts to log
  the result. It is unclear whether this works, because I am unsure of any
  soecific way to trigger the exception. So if it is not doing any harm,
  perhaps we can put this in production, and then see what we get in the log
  from factoring attempts.
  It also improves some of the advice/pointers for finding log information
  on the server.