### PR TITLE
fix: Move all calls to cypari into try-except block

### DIFF
--- a/flaskr/nscope/views.py
+++ b/flaskr/nscope/views.py
@@ -308,7 +308,7 @@ def fetch_factors(oeis_id, num_elements = -1):
     if len_factors >= num_elements:
         return seq
     # Factor whatever else is requested, within reason.
-    pari = cypari2.Pari()
+    pari = None
     for i in range(len_factors, num_elements):
         val = int(seq.values[i])
         # the factorization of 1 is empty
@@ -321,6 +321,7 @@ def fetch_factors(oeis_id, num_elements = -1):
                 # elements are arrays [p, e] for factor p^e
                 # including [-1,1] for negative numbers
                 # and [0,1] for zero
+                if not pari: pari = cypari2.Pari()
                 fac = gen_to_python(pari(val).factor())
             except Exception as ex:
                 log = log.bind(exception = ex, value = val)


### PR DESCRIPTION
Even with #145, production is still producing a 502 Bad Gateway on https://numberscope.colorado.edu/api/get_oeis_factors/A000045/128, so this PR moves the cypari call that is now erroring into the try-catch block in the hopes that we can at least get a sensible (if incomplete) response for factor requests, to allow moving forward with frontscope. As with #145, this merely allows the server to respond in the face of #143, not really dealing with the underlying issue that we need reliable factoring. However, if someone can review and merge, I can install it in production and hope that gets us back in operation for the frontscope, at least.