### PR TITLE
feat: Add search_oeis endpoint

### DIFF
--- a/doc/api_endpoints.md
+++ b/doc/api_endpoints.md
@@ -134,8 +134,8 @@ SEARCH_TERM, which should be url encoded if it contains any characters
 disallowed in urls. Currently the search criterion is identical to whatever
 the OEIS does when you type SEARCH_TERM into its search box. For example,
 if you are running the server on your local machine, a full URL would be
-http://127.0.0.1:5000/api/search_oeis/germaine which gives results concerning
-Sophie Germaine primes.
+http://127.0.0.1:5000/api/search_oeis/germain which gives results concerning
+Sophie Germain primes.
 
 #### Key: term
 

--- a/doc/api_endpoints.md
+++ b/doc/api_endpoints.md
@@ -127,3 +127,20 @@ A string showing the short hash resulting from calling
 git rev-parse --short HEAD
 ```
 
+### URL: `api/search_oeis/<SEARCH_TERM>`
+
+Returns up to ten (id, sequence-name) pairs of sequences matching the
+SEARCH_TERM, which should be url encoded if it contains any characters
+disallowed in urls. Currently the search criterion is identical to whatever
+the OEIS does when you type SEARCH_TERM into its search box.
+
+#### Key: term
+
+A string giving the search term as supplied.
+
+#### Key: results
+
+An array of results. Each element in the array is a two-element array
+of strings. The first entry of each of these arrays is an OEIS id in "Annnnnn"
+format, and the second is the OEIS name of the corresponding sequence.
+

--- a/doc/api_endpoints.md
+++ b/doc/api_endpoints.md
@@ -132,7 +132,10 @@ git rev-parse --short HEAD
 Returns up to ten (id, sequence-name) pairs of sequences matching the
 SEARCH_TERM, which should be url encoded if it contains any characters
 disallowed in urls. Currently the search criterion is identical to whatever
-the OEIS does when you type SEARCH_TERM into its search box.
+the OEIS does when you type SEARCH_TERM into its search box. For example,
+if you are running the server on your local machine, a full URL would be
+http://127.0.0.1:5000/api/search_oeis/germaine which gives results concerning
+Sophie Germaine primes.
 
 #### Key: term
 

--- a/doc/api_endpoints.md
+++ b/doc/api_endpoints.md
@@ -20,7 +20,7 @@ OEIS.
 This is the most rapid endpoint, it makes at most one request to the OEIS server
 (and only if the OEIS_ID has not previously been requested). If you are running
 the server to test it on your local host, a full URL would be
-`http://127.0.0.1:5000/api/get_oeis_values/A000030/50` which will return the
+http://127.0.0.1:5000/api/get_oeis_values/A000030/50 which will return the
 first digits of the numbers 0 through 49.
 
 #### Key: name
@@ -40,7 +40,7 @@ datatype.
 This one is potentially a bit slower than the above URL, as it may make
 an extra request to ensure that the name is correct. If you are running
 the server on your local host, a full URL would be
-`http://127.0.0.1:5000/api/get_oeis_name_and_values/A003173`, which will
+http://127.0.0.1:5000/api/get_oeis_name_and_values/A003173, which will
 return the nine Heegner numbers and their full name as an OEIS
 sequence (basically, the name describes what a Heegner number is).
 
@@ -59,7 +59,7 @@ A potentially very slow endpoint (if the sequence is unknown to the backscope);
 may make hundreds of requests to the OEIS to generate all of the back
 references to the sequence. If you are running the server on your local
 machine, a full URL would be
-`http://127.0.0.1:5000/api/get_oeis_metadata/A028444` which will show the full
+http://127.0.0.1:5000/api/get_oeis_metadata/A028444 which will show the full
 name of the Busy Beaver sequence, the one text line of sequences it
 references, and the IDs of the ten sequences that refer to it.
 
@@ -83,7 +83,7 @@ This could take a long time. It internally does everything that the endpoint
 it proceeds to factor the first `<COUNT>` terms of the sequence (or all of them
 if there are not that many). If you are running the server to test it on your
 local host, a full URL would be
-`http://127.0.0.1:5000/api/get_oeis_factors/A006862/50` which will return the
+http://127.0.0.1:5000/api/get_oeis_factors/A006862/50 which will return the
 factorizations of 1 + the product of the first n primes, for n < 50. The
 first 42 terms will be factored and larger terms will return `no_fac` (since
 they are deemed too large to factor in a reasonable time).
@@ -116,8 +116,7 @@ the factorization is stored as `no_fac`.
 
 Returns the most recent git hash of the currently running version of
 backscope.  If you are running the server on your local
-machine, a full URL would be
-`http://127.0.0.1:5000/api/get_commit`
+machine, a full URL would be http://127.0.0.1:5000/api/get_commit.
 
 #### Key: short_commit_hash
 

--- a/flaskr/nscope/models.py
+++ b/flaskr/nscope/models.py
@@ -54,9 +54,14 @@ class Sequence(db.Model):
         ret = self.query.filter_by(id=id).first()
         return ret
 
+class Search(db.Model):
+    __tablename__ = 'searches'
 
+    term = db.Column(db.String, unique=True, nullable=False, primary_key=True)
+    ids = db.Column(db.ARRAY(db.String), unique=False, nullable=True)
+    names = db.Column(db.ARRAY(db.String), unique=False, nullable=True)
 
-
-
-
-
+    @classmethod
+    def get_search_by_term(self, term):
+        ret = self.query.filter_by(term=term).first()
+        return ret

--- a/flaskr/nscope/test/test_search_oeis.py
+++ b/flaskr/nscope/test/test_search_oeis.py
@@ -1,0 +1,34 @@
+import unittest
+import flaskr.nscope.test.abstract_endpoint_test as abstract_endpoint_test
+
+
+class TestSearchOEIS(abstract_endpoint_test.AbstractEndpointTest):
+  endpoint = 'http://localhost:5000/api/search_oeis/germain'
+  
+  expected_response = {
+    'term': 'germain',
+    'results': [
+      ['A005384', 'Sophie Germain primes p: 2p+1 is also prime.'],
+      ['A059455', 'Safe primes which are also Sophie Germain primes.'],
+      ['A111153',
+       'Sophie Germain semiprimes: semiprimes n such that '
+       + '2n+1 is also a semiprime.'],
+      ['A059452', 'Safe primes (A005385) that are not Sophie Germain primes.'],
+      ['A156660', 'Characteristic function of Sophie Germain primes.'],
+      ['A111206',
+       'Semi-Sophie Germain semiprimes: semiprimes which are the product '
+       + 'of Sophie Germain primes.'],
+      ['A209253',
+       'Number of ways to write 2n-1 as the sum of a Sophie Germain prime '
+       + 'and a practical number.'],
+      ['A124174',
+       'Sophie Germain triangular numbers tr: 2*tr+1 is also a '
+       + 'triangular number.'],
+      ['A157342',
+       'Semiprimes that are the product of two non-Sophie Germain primes.'],
+      ['A156874', 'Number of Sophie Germain primes <= n.'],
+    ]
+  }
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Now that backscope is stable once again, to progress further with the OEIS search bar in the frontscope, it seems prudent to add a search_oeis endpoint to backscope, rather than have the frontscope go directly to the OEIS. That way,
the frontscope is consistently talking only to the backscope, and when/if we convert backscope to have all metadata present on the server by virtue of checking out the git mirror of the OEIS, we can switch to doing the search locally on the server (no need to hit the OEIS) in a seamless fashion from the point of view of the front end.
